### PR TITLE
fix utils/find_chez_scheme_dir.sh for alpine linux

### DIFF
--- a/utils/find_chez_scheme_dir.sh
+++ b/utils/find_chez_scheme_dir.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-( chezscheme --verbose < /dev/null 2>&1 || scheme --verbose < /dev/null 2>&1 ) \
-  | grep 'scheme.boot...opened' \
-  | sed -e 's,^trying ,,g' -e 's,/chezscheme.boot...opened,,g' -e 's,/scheme.boot...opened,,g'
+( chezscheme --verbose < /dev/null 2>&1 || scheme --verbose < /dev/null 2>&1 || chez --verbose < /dev/null 2>&1 ) \
+  | grep -E '(chez|scheme)\.boot\.\.\.opened' \
+  | sed -e 's,^trying ,,g' -e 's,/chezscheme.boot...opened,,g' -e 's,/scheme.boot...opened,,g' -e 's,/chez.boot...opened,,g'


### PR DESCRIPTION
On alpine linux, the chez binary is named `chez`,  which prevented the `utlis/find_chez_scheme_dir.sh` script from finding the chez dir.

This PR fixes that