### PR TITLE
posix: thread: fix for support chez scheme with version < 10

### DIFF
--- a/posix/thread.ss
+++ b/posix/thread.ss
@@ -11,7 +11,8 @@
   (export get-initial-thread thread thread-count thread-find thread-id thread-list)
   (import
     (rnrs)
-    (only (chezscheme)         $primitive meta-cond foreign-procedure import thread? threaded?)
+    (only (chezscheme)         $primitive meta-cond foreign-procedure import thread? threaded?
+                               scheme-version-number)
     (only (schemesh bootstrap) assert* raise-errorf))
 
 
@@ -82,7 +83,9 @@
 
 (define get-initial-thread
   (meta-cond
-    ((threaded?)
+    ((and (threaded?)
+          (let-values ([(maj min sub) (scheme-version-number)])
+            (>= maj 10)))
       (let ()
          (import (prefix (only (chezscheme) get-initial-thread)
                          chez:))


### PR DESCRIPTION
(get-initial-thread) was introduced in v10.x.x so add an extra check before importing it.