### PR TITLE
posix: thread: fix checking for get-initial-thread

### DIFF
--- a/posix/thread.ss
+++ b/posix/thread.ss
@@ -85,7 +85,7 @@
     ;; Chez Scheme exports get-initial-thread only in versions >= 10.0.0
     ;; and only in threaded builds: check if it's actually present,
     ;; rather than relying on version numbers
-    ((memq 'get-initial-thread? (library-exports '(chezscheme)))
+    ((memq 'get-initial-thread (library-exports '(chezscheme)))
       (let ()
          (import (prefix (only (chezscheme) get-initial-thread)
                          chez:))


### PR DESCRIPTION
Remove '?' from the 'get-initial-thread? symbol name.