### PR TITLE
fix: include lz4 and zlib in patchelf rpath in nix derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,6 @@ in
       chmod +x $out/bin/schemesh
 
       patchelf $out/bin/schemesh --set-rpath \
-        "${pkgs.lib.makeLibraryPath [ pkgs.ncurses pkgs.libuuid ]}"
+        "${pkgs.lib.makeLibraryPath [ pkgs.ncurses pkgs.libuuid pkgs.lz4 pkgs.zlib ]}"
     '';
   }


### PR DESCRIPTION
The nix derivation was missing lz4 and zlib in its patchelf RPATH.