### PR TITLE
fix build error on macOS

### DIFF
--- a/c/dir.c
+++ b/c/dir.c
@@ -27,6 +27,7 @@
 #include "writer.h"
 
 #ifdef __APPLE__
+#include <sys/syslimits.h> /* PATH_MAX */
 #undef SCHEME2K_C_DIR_HAVE_TIMESPEC
 #else
 #define SCHEME2K_C_DIR_HAVE_TIMESPEC


### PR DESCRIPTION
```sh
cc -o dir c/dir.c -O2 -pipe -Wall -W -Wextra -s
c/dir.c:290:17: error: use of undeclared identifier 'PATH_MAX'
  290 |     char    buf[PATH_MAX];
      |                 ^~~~~~~~
1 error generated.
make: *** [Makefile:176: dir] Error 1
```
See https://github.com/cosmos72/schemesh/issues/34#issuecomment-4231026013