### PR TITLE
nix: add flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,47 @@
+name: nix
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (${{ matrix.system }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: ubuntu-latest
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - system: aarch64-darwin
+            runner: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      # The Makefile builds schemesh_test and runs it during buildPhase, so a
+      # successful build means the test suite passed on this platform.
+      - run: nix build --print-build-logs .#packages.${{ matrix.system }}.schemesh
+
+  check:
+    name: flake check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix flake check --print-build-logs
+      - run: nix fmt -- --check flake.nix default.nix package.nix shell.nix

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.so
 a.out
 \#*#
+/result
+/result-*

--- a/README.md
+++ b/README.md
@@ -720,28 +720,37 @@ sudo make install
 
 #### Nix/NixOS
 *WARNING* build instructions for Nix/NixOS below are user-contributed, and the author has very little expertise to investigate possible issues.
+
+Supported systems: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`.
+`x86_64-darwin` is absent because nixpkgs 26.11 dropped it, and needs a 26.05 channel.
+
 ```shell
-# Build and run by cloning source repository
-git clone https://github.com/cosmos72/schemesh
-cd schemesh
-nix-build && ./result/bin/schemesh
+nix run     github:cosmos72/schemesh   # try schemesh without installing it
+nix build   github:cosmos72/schemesh   # build into ./result
+nix develop github:cosmos72/schemesh   # dev shell, then `make -j`
 ```
 
+Without flakes, from a clone of the source repository:
+```shell
+nix-build && ./result/bin/schemesh
+nix-shell                              # dev shell, then `make -j`
+```
+
+Both use the same derivation, [package.nix](package.nix).
+
+Install on NixOS via the overlay:
 ```nix
-# Install on NixOS as package
-{ pkgs, ... }:
-let
-  schemesh = pkgs.fetchgit {
-    url = "https://github.com/cosmos72/schemesh.git";
-    rev = "refs/tags/v1.0.1"; # or: "refs/heads/main"
-    sha256 = ""; # insert sha256 when ready
-  };
 {
-  environment.systemPackages = [
-    # ...
-    pkgs.chez
-    (callPackage schemesh {})
-  ];
+  inputs.schemesh.url = "github:cosmos72/schemesh";
+
+  outputs = { nixpkgs, schemesh, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [
+        { nixpkgs.overlays = [ schemesh.overlays.default ]; }
+        { environment.systemPackages = [ pkgs.schemesh ]; }
+      ];
+    };
+  };
 }
 ```
 
@@ -779,9 +788,17 @@ If `make -j` fails, do not panic :) Some issues are relatively minor and can be 
 4. on macOS + Nix, launching `schemesh` may fail with an error message similar to
    ```schemesh: Exception: incompatible fasl-object version 0.0.0-pre-release.20 found in result/lib/schemesh/libschemesh_X.Y.X.so```
 
-   It is likely caused by an issue in Nix rules for building Chez Scheme - see [issue #34](https://github.com/cosmos72/schemesh/issues/34#issuecomment-4231026013) for more details.
+   It is caused by Nix's `fixupPhase`, which strips `$out/lib` by default.
+   `libschemesh_X.Y.Z.so` is a Chez Scheme fasl object, not a native shared library,
+   and Apple's `strip` truncates it to 24 bytes. Check with
+   `ls -l result/lib/schemesh/libschemesh_*.so`
 
-   Workaround: either follow the instructions for plain macOS i.e. **without** Nix, or (untested) apply the user-contributed patch listed in the issue linked above.
+   Fixed in [package.nix](package.nix) by stripping only `$out/bin`:
+   ```nix
+   stripDebugList = [ "bin" ];
+   ```
+   Earlier diagnosis in [issue #34](https://github.com/cosmos72/schemesh/issues/34#issuecomment-4231026013)
+   attributed this to Chez Scheme's Nix build rules; that is not the cause.
 
 If you get some other error and you correctly installed the required dependencies,
 feel free to open a [GitHub issue](https://github.com/cosmos72/schemesh/issues)

--- a/default.nix
+++ b/default.nix
@@ -1,39 +1,7 @@
-{ pkgs ? import <nixpkgs> {} }:
-let
-  versionLatest =
-    builtins.head
-      (builtins.match ".*Schemesh Version ([0-9.]+).*"
-        (builtins.readFile ./bootstrap/functions.ss));
-in
-  pkgs.stdenv.mkDerivation {
-    name = "schemesh";
-    version = versionLatest;
-    src = ./.;
+# Compatibility entry point for `nix-build` (flakes not required).
+# The package itself is defined in ./package.nix, which flake.nix also uses.
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
-    buildInputs = [
-      pkgs.chez    # Ubuntu: chezscheme-dev
-      pkgs.lz4     # Ubuntu: liblz4-dev
-      pkgs.ncurses # Ubuntu: libncurses-dev
-      pkgs.libuuid # Ubuntu: uuid-dev
-      pkgs.zlib    # Ubuntu: zlib1g-dev
-    ];
-
-    nativeBuildInputs = [
-      pkgs.patchelf
-    ];
-
-    buildPhase = ''
-      make -j prefix=$out
-    '';
-
-    installPhase = ''
-      mkdir -p $out/bin $out/lib/schemesh
-
-      cp schemesh $out/bin/schemesh
-      cp "libschemesh_${versionLatest}.so" $out/lib/schemesh/
-      chmod +x $out/bin/schemesh
-
-      patchelf $out/bin/schemesh --set-rpath \
-        "${pkgs.lib.makeLibraryPath [ pkgs.ncurses pkgs.libuuid pkgs.lz4 pkgs.zlib ]}"
-    '';
-  }
+pkgs.callPackage ./package.nix { }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "A Unix shell and Lisp REPL, fused together";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: rec {
+        schemesh = pkgs.callPackage ./package.nix { };
+        default = schemesh;
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = import ./shell.nix {
+          inherit pkgs;
+          schemesh = self.packages.${pkgs.stdenv.hostPlatform.system}.schemesh;
+        };
+      });
+
+      overlays.default = final: prev: {
+        schemesh = final.callPackage ./package.nix { };
+      };
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt);
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  chez,
+  lz4,
+  ncurses,
+  zlib,
+  libuuid,
+  libiconv,
+}:
+
+let
+  # Single source of truth for the version: bootstrap/functions.ss
+  version = builtins.head (
+    builtins.match ".*Schemesh Version ([0-9.]+).*" (builtins.readFile ./bootstrap/functions.ss)
+  );
+in
+stdenv.mkDerivation {
+  pname = "schemesh";
+  inherit version;
+
+  # The whole working tree, minus VCS metadata. Deliberately *not* pruned any
+  # further: test/data3.ss glob-expands the source root and asserts on the
+  # result, so the build tree has to match what a developer sees in a checkout.
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.difference ./. (lib.fileset.maybeMissing ./.git);
+  };
+
+  strictDeps = true;
+
+  # `scheme` is needed on $PATH at build time: utils/find_chez_scheme_dir.sh runs it
+  # to locate the boot/kernel directory that the Makefile compiles and links against.
+  nativeBuildInputs = [ chez ];
+
+  buildInputs = [
+    chez
+    lz4
+    ncurses
+    zlib
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ libuuid ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "prefix=${placeholder "out"}"
+  ]
+  # The Makefile defaults to `LDFLAGS=-s`, which Apple's ld64 no longer accepts.
+  # Nix strips binaries in a separate phase anyway.
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ "LDFLAGS=" ];
+
+  enableParallelBuilding = true;
+
+  # lib/schemesh/libschemesh_$VERSION.so is a Chez Scheme fasl object, not a native
+  # shared library. The default fixupPhase strip truncates it to 24 bytes, and the
+  # resulting binary dies with "incompatible fasl-object version". Only strip bin/.
+  stripDebugList = [ "bin" ];
+
+  # `make` builds schemesh_test and runs it to produce libschemesh_$VERSION.so,
+  # so the test suite is already exercised during buildPhase.
+  doCheck = false;
+
+  meta = {
+    description = "Fusion between a Unix shell and a Lisp REPL";
+    homepage = "https://github.com/cosmos72/schemesh";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "schemesh";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+# Development shell, shared by `nix-shell` and `nix develop`.
+{
+  pkgs ? import <nixpkgs> { },
+  schemesh ? pkgs.callPackage ./package.nix { },
+}:
+
+pkgs.mkShell {
+  # Pull in chez, lz4, ncurses, zlib and the platform-specific libs.
+  inputsFrom = [ schemesh ];
+
+  packages = [
+    pkgs.clang-tools # clang-format, honours ./.clang-format
+  ]
+  ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.gdb ];
+
+  shellHook = ''
+    echo "schemesh dev shell"
+    echo "  build: make -j"
+    echo "  test:  ./schemesh_test"
+  '';
+}

--- a/test/data3.ss
+++ b/test/data3.ss
@@ -392,7 +392,7 @@
 
   ;; ------------------------- wildcard expansion -------------------------
   (wildcard1+ #t "a" "bcd" "" "ef")                    ("abcdef")
-  (wildcard1+ #t '* "f" '* "l" '*)                     ("Makefile" "default.nix" "reflect")
+  (wildcard1+ #t '* "f" '* "l" '*)                     ("Makefile" "default.nix" "flake.lock" "flake.nix" "reflect")
   (wildcard->sh-patterns '(*))                       ,@(span (sh-pattern '*))
   (wildcard->sh-patterns '("/" * ".so"))             ,@(span "/" (sh-pattern '* ".so"))
   (wildcard->sh-patterns '("//abc//" "//def//"))     ,@(span "/" "abc/" "def/")


### PR DESCRIPTION
Adds a Nix flake providing a package and dev shell for x86_64-linux, aarch64-linux and aarch64-darwin. The derivation lives in `package.nix`; `default.nix` and `shell.nix` are thin wrappers around it, so `nix-build`/`nix-shell` still work without flakes.

Fixes #34 correctly on macOS. The `incompatible fasl-object version` error is not a Chez packaging problem: Nix's `fixupPhase` strips `$out/lib`, and Apple's `strip` truncates the fasl object entirely. Corrected with `stripDebugList = [ "bin" ]`.

`test/data3.ss:395` glob-expands the source root, so its expectation now includes `flake.nix` and `flake.lock`.

 Tested on aarch64-darwin and x86_64-linux.

```
user@machine:~$ echo '((lambda (n) (+ n n)) 4)' | nix run github:jdek/schemesh/flake
shell user@machine:~:((lambda (n) (+ n n)) 4)
8
shell user@machine:~:
user@machine:~$
```